### PR TITLE
fix(perception): fix bbox height is not correct

### DIFF
--- a/src/converters/PerceptionConverter.ts
+++ b/src/converters/PerceptionConverter.ts
@@ -136,7 +136,7 @@ function createCubePrimitive(
         x: position.x,
         y: position.y,
         // make the cube start at the ground level (z = 0)
-        z: position.z - 0.5 * dimensions.z,
+        z: position.z,
       },
       orientation,
     },


### PR DESCRIPTION
# Summary
This PR is checked with m1 mac and latest lichtblick release.

- current bbox height is not correct with my environments
- this pr fixes bbox z axis position


# to be checked

I did not check this pr with ubuntu pc yet, so please checkit carefully